### PR TITLE
Improve lexicographic comparison of small integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,6 @@ and the results must be taken as partial
 -  *inlining* is surely playing an active role in `timsort` module's good performance
 -  A more accurate comparison of the algorithms would require implementing `array.sort` in pure javascript 
 and counting element comparisons
--  `array.sort` will probably still be faster at lexicographically sorting 
-arrays of numbers. In this case, the `timsort` module inefficiently converts 
-values to strings inside the compare function and then compares the strings. 
-`array.sort`, instead, uses a smarter and faster lexicographic 
-comparison of numbers (will try to do something similar soon).
 
 ## Stability
 

--- a/src/timsort.js
+++ b/src/timsort.js
@@ -15,6 +15,42 @@ const DEFAULT_MIN_GALLOPING = 7;
 const DEFAULT_TMP_STORAGE_LENGTH = 256;
 
 /**
+ * Pre-computed powers of 10 for efficient lexicographic comparison of
+ * small integers.
+ */
+const POWERS_OF_TEN = [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9]
+
+/**
+ * Estimate the logarithm base 10 of a small integer.
+ *
+ * @param {number} x - The integer to estimate the logarithm of.
+ * @return {number} - The estimated logarithm of the integer.
+ */
+function log10(x) {
+  if (x < 1e5) {
+    if (x < 1e2) {
+      return x < 1e1 ? 0 : 1;
+    }
+
+    if (x < 1e4) {
+      return x < 1e3 ? 2 : 3;
+    }
+
+    return 4;
+  }
+
+  if (x < 1e7) {
+    return x < 1e6 ? 5 : 6;
+  }
+
+  if (x < 1e9) {
+    return x < 1e8 ? 7 : 8;
+  }
+
+  return 9;
+}
+
+/**
  * Default alphabetical comparison of items.
  *
  * @param {string|object|number} a - First element to compare.
@@ -25,18 +61,56 @@ const DEFAULT_TMP_STORAGE_LENGTH = 256;
 function alphabeticalCompare(a, b) {
   if (a === b) {
     return 0;
-
-  } else {
-    let aStr = String(a);
-    let bStr = String(b);
-
-    if (aStr === bStr) {
-      return 0;
-
-    } else {
-      return aStr < bStr ? -1 : 1;
-    }
   }
+
+  if (~~a === a && ~~b === b) {
+    if (a === 0 || b === 0) {
+      return a < b ? -1 : 1;
+    }
+
+    if (a < 0 || b < 0) {
+      if (b >= 0) {
+        return -1;
+      }
+
+      if (a >= 0) {
+        return 1;
+      }
+
+      a = -a;
+      b = -b;
+    }
+
+    const al = log10(a);
+    const bl = log10(b);
+
+    let t = 0;
+
+    if (al < bl) {
+      a *= POWERS_OF_TEN[bl - al - 1];
+      b /= 10;
+      t = -1;
+    } else if (al > bl) {
+      b *= POWERS_OF_TEN[al - bl - 1];
+      a /= 10;
+      t = 1;
+    }
+
+    if (a === b) {
+      return t;
+    }
+
+    return a < b ? -1 : 1;
+  }
+
+  let aStr = String(a);
+  let bStr = String(b);
+
+  if (aStr === bStr) {
+    return 0;
+  }
+
+  return aStr < bStr ? -1 : 1;
 }
 
 /**


### PR DESCRIPTION
This PR adds an improved implementation of lexicographic comparison of 32-bit integers as natively implemented in V8:

https://github.com/v8/v8/blob/8e02f47/src/runtime/runtime-numbers.cc#L197-L270

Unlike the V8 implementation, the implementation of `log10` estimation relies solely on comparisons whereas V8 uses a bit twiddling hack. My guess is that this is why the pure-JS implementation is in fact able to outperform V8.
