### PR TITLE
Prevent integer overflow during midpoint calculation in `binaryInsertionSort`

### DIFF
--- a/src/timsort.js
+++ b/src/timsort.js
@@ -208,7 +208,7 @@ function binaryInsertionSort(array, lo, hi, start, compare) {
      *   pivot <  array[i] for i in  in [right, start)
      */
     while (left < right) {
-      let mid = (left + right) >>> 1;
+      let mid = left + ((right - left) >>> 1);
 
       if (compare(pivot, array[mid]) < 0) {
         right = mid;


### PR DESCRIPTION
Changed line 211 from

`let mid = (left + right) >>> 1;`

to

`let mid = left + ((right - left) >>> 1);`

because the previous implementation would yield incorrect results for large values of `left` and/or `right`.

This is the way the operation is done, for example, in `gallopLeft` on line 315