### PR TITLE
Add TypeScript Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+declare module 'timsort' {
+  function sort<T>(xs: Array<T>): void;
+  function sort<T>(xs: Array<T>, comparator: (a: T, b: T) => number): void;
+  function sort<T>(xs: Array<T>, rangeFrom: number, rangeTo: number): void;
+  function sort<T>(
+    xs: Array<T>,
+    comparator: (a: T, b: T) => number,
+    rangeFrom: number,
+    rangeTo: number
+  ): void;
+
+  export { sort };
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "description": "TimSort: Fast Sorting for Node.js",
   "homepage": "https://github.com/mziccard/node-timsort",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "./test",
     "benchmark": "./benchmark"


### PR DESCRIPTION
I'd love to contribute typing information for TypeScript so `node-timesort` can be used there without hickups.